### PR TITLE
支持keil AC5下选中全局GNU扩展模式

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -1,5 +1,6 @@
 Import('rtconfig')
 from building import *
+import os
 import shutil
 
 src = ['perf_counter.c', 'os/perf_os_patch_rt_thread.c']
@@ -20,6 +21,6 @@ try:
 except:
     pass
 
-group = DefineGroup('perf_counter', src, depend = ['PKG_USING_PERF_COUNTER'], CPPDEFINES = CPPDEFINES, CPPPATH = path)
+group = DefineGroup('perf_counter', src, depend = ['PKG_USING_PERF_COUNTER'], CPPDEFINES = CPPDEFINES, CPPPATH = path, CXXFLAGS = ' --gnu')
 
 Return('group')


### PR DESCRIPTION
RT-Thread最新代码支持该功能，生成KeilAC5工程时可以全局选定GNU扩展
https://github.com/RT-Thread/rt-thread/pull/6875