### PR TITLE
Add macro TX_EXECUTION_PROFILE_ENABLE

### DIFF
--- a/os/perf_os_patch_threadx.c
+++ b/os/perf_os_patch_threadx.c
@@ -44,9 +44,10 @@
 #define ORIG_FUNC(__NAME)       __ORIG_FUNC(__NAME)
 
 
-#ifndef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
-#error In order to use perf_counter:ThreadX-Patch, please define\
- TX_ENABLE_EXECUTION_CHANGE_NOTIFY in the project configuration.\
+#if defined(TX_ENABLE_EXECUTION_CHANGE_NOTIFY) && defined(TX_EXECUTION_PROFILE_ENABLE)
+#error In order to use perf_counter:ThreadX-Patch, please define  \
+ TX_ENABLE_EXECUTION_CHANGE_NOTIFY or TX_EXECUTION_PROFILE_ENABLE \
+ in the project configuration, according to the version of thread.\
  If you don't want to use this patch, please un-select it in RTE\
  or remove this patch from the compilation.
 #endif


### PR DESCRIPTION
Add the macro TX_EXECUTION_PROFILE_ENABLE to perf_os_patch_threadx.c.
According to the description of  `tx_api.h` in Line 604:

```c
    /* Define variables for supporting execution profile. */
    /* Note that in ThreadX 5.x, user would define TX_ENABLE_EXECUTION_CHANGE_NOTIFY and use TX_THREAD_EXTENSION_3
       to define the following two variables.
       For Azure RTOS 6, user shall use TX_EXECUTION_PROFILE_ENABLE instead of TX_ENABLE_EXECUTION_CHANGE_NOTIFY,
       and SHALL NOT add variables to TX_THREAD_EXTENSION_3. */
#if (defined(TX_EXECUTION_PROFILE_ENABLE) && !defined(TX_ENABLE_EXECUTION_CHANGE_NOTIFY))
    EXECUTION_TIME              tx_thread_execution_time_total;
    EXECUTION_TIME_SOURCE_TYPE  tx_thread_execution_time_last_start;
#endif
```

In Azure RTOS 6, we should use "TX_EXECUTION_PROFILE_ENABLE" to replace "TX_ENABLE_EXECUTION_CHANGE_NOTIFY". This conflicts with the following part in `perf_os_patch_threadx.c`:

```c
#ifndef TX_ENABLE_EXECUTION_CHANGE_NOTIFY
#error In order to use perf_counter:ThreadX-Patch, please define\
 TX_ENABLE_EXECUTION_CHANGE_NOTIFY in the project configuration.\
 If you don't want to use this patch, please un-select it in RTE\
 or remove this patch from the compilation.
#endif
```

Therefore, I have submitted this PR. Welcome to your reply.